### PR TITLE
fix parsing of prepaid accounts

### DIFF
--- a/src/Monzo.lua
+++ b/src/Monzo.lua
@@ -115,7 +115,7 @@ function ListAccounts(knownAccounts)
       -- String owner: Name des Kontoinhabers
       owner = ownerForMonzoAccountOwners(account.owners),
       -- String accountNumber: Kontonummer
-      accountNumber = account.account_number .. " ", -- enforces that MoneyMoney will not hide a leading zero
+      accountNumber = (account.account_number or account.id) .. " ", -- enforces that MoneyMoney will not hide a leading zero
       -- String subAccount: Unterkontomerkmal
       subAccount = account.id,
       -- Boolean portfolio: true für Depots und false für alle anderen Konten
@@ -169,7 +169,9 @@ end
 
 function formatSortCode(sortCode)
   local result = ""
-
+  if sortCode == nil then
+    return result
+  end
   for i = 1, #sortCode do
     local char = sortCode:sub(i, i)
 
@@ -363,3 +365,5 @@ function RecPrint(s, l, i) -- recursive Print (structure, limit, indent)
   end
   return l
 end
+
+-- SIGNATURE: MC0CFEgMBsbYgKX6rf0Nf2DWH3duMQasAhUAjKviTQ0sMlHUdpPmqmTfT2cMKZA=


### PR DESCRIPTION
prepaid accounts don't have an account number, nor a sortcode

Also, given we don't have access to the email anymore (and this was the identifier before),
MoneyMoney recreates those accounts for us. Which is fair - but that means users will need to re-tag all
their entries. 🤷‍♂️🌳🤷‍♀️  Sorry about that!