### PR TITLE
Move OAuth redirect to repo-owned GitHub Pages

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Inofficial extension to fetch transactions from [Monzo](https://monzo.com) for [
 ### Create OAuth Client
 * Create a new Monzo app via https://developers.monzo.com/
   * Create a new OAuth client via https://developers.monzo.com/apps/new
-  * Add `https://www.janmuennich.com/moneymoney-redirect/` in the *Redirect URLs* field (see [OAuth Redirect](#oauth-redirect) below)
+  * Add `https://diederich.github.io/moneymoney-monzo/oauth-redirect/` in the *Redirect URLs* field (see [OAuth Redirect](#oauth-redirect) below)
   * Add something to the other fields, e.g. `MyMoneyMoneyExtension` as Name
   * Set *Confidentiality* to *Not Confidential*
   * Tap *Submit*
@@ -48,11 +48,15 @@ Inofficial extension to fetch transactions from [Monzo](https://monzo.com) for [
 
 # OAuth Redirect
 
-MoneyMoney uses the custom URL scheme `moneymoney-app://oauth` to receive OAuth callbacks. However, Monzo's login confirmation email filters out non-HTTPS URLs, replacing them with a broken link. This means the magic link in the email will not work if `moneymoney-app://oauth` is used as the redirect URL directly.
+MoneyMoney uses the custom URL scheme `moneymoney-app://oauth` to receive OAuth callbacks. However, Monzo's login confirmation email filters out non-HTTPS URLs, replacing them with a broken link. To work around this, the extension uses an HTTPS bridge page that immediately forwards the callback back to MoneyMoney.
 
-To work around this, the extension uses an HTTPS redirect URL that forwards to the `moneymoney-app://oauth` scheme. By default, this is set to `https://www.janmuennich.com/moneymoney-redirect/`. The redirect service simply passes through the query parameters (authorization code and state) without storing any data.
+By default this bridge is hosted as a static GitHub Pages page from this repository at `https://diederich.github.io/moneymoney-monzo/oauth-redirect/`. The page is a single static HTML file ([`docs/oauth-redirect/index.html`](docs/oauth-redirect/index.html)) that forwards the browser to `moneymoney-app://oauth` with the original query string. No data is stored or sent to any third party.
 
-If you prefer to host your own redirect, set up a simple script on your server and update the `REDIRECT_URI` variable at the top of `Monzo.lua`. For example, using PHP:
+## Self-Hosting
+
+If you prefer to host your own redirect, update the `REDIRECT_URI` variable at the top of `Monzo.lua` and register the matching URL in your Monzo OAuth client at https://developers.monzo.com/.
+
+For a self-hosted static version, use [`docs/oauth-redirect/index.html`](docs/oauth-redirect/index.html) from this repository as a starting point. For a PHP-based redirect:
 
 ```php
 <?php

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; style-src 'unsafe-inline'; img-src https://github.githubassets.com; base-uri 'none'; form-action 'none'"
+    />
+    <meta name="robots" content="noindex" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>moneymoney-monzo</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+        max-width: 42rem;
+        margin: 3rem auto;
+        padding: 0 1rem;
+        line-height: 1.5;
+      }
+    </style>
+  </head>
+  <body>
+    <a href="https://github.com/diederich/moneymoney-monzo" aria-label="View on GitHub" style="position:fixed;top:1rem;right:1rem">
+      <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" width="32" height="32" />
+    </a>
+    <h1>moneymoney-monzo</h1>
+    <p>
+      This site hosts the
+      <a href="oauth-redirect/">OAuth redirect page</a>
+      for the
+      <a href="https://github.com/diederich/moneymoney-monzo">moneymoney-monzo</a>
+      <a href="https://moneymoney-app.com">MoneyMoney</a> extension.
+    </p>
+  </body>
+</html>

--- a/docs/oauth-redirect/index.html
+++ b/docs/oauth-redirect/index.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src https://github.githubassets.com; base-uri 'none'; form-action 'none'"
+    />
+    <meta name="robots" content="noindex" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Redirecting to MoneyMoney…</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+        max-width: 42rem;
+        margin: 3rem auto;
+        padding: 0 1rem;
+        line-height: 1.5;
+      }
+    </style>
+  </head>
+  <body>
+    <a href="https://github.com/diederich/moneymoney-monzo" aria-label="View on GitHub" style="position:fixed;top:1rem;right:1rem">
+      <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" width="32" height="32" />
+    </a>
+    <h1>Redirecting to MoneyMoney…</h1>
+    <p>This page only forwards the OAuth response back to <a href="https://moneymoney-app.com">MoneyMoney</a>.</p>
+    <p id="status">Attempting automatic redirect…</p>
+    <p id="fallback" hidden>
+      If nothing happens, <a id="link" rel="nofollow">open MoneyMoney manually</a>.
+    </p>
+    <noscript><p>JavaScript is required for the redirect to work.</p></noscript>
+
+    <script>
+      (function () {
+        var target = "moneymoney-app://oauth" + window.location.search + window.location.hash;
+        document.getElementById("link").href = target;
+
+        setTimeout(function () {
+          document.getElementById("fallback").hidden = false;
+          document.getElementById("status").textContent =
+            "Your browser may require a manual click.";
+        }, 800);
+
+        window.location.replace(target);
+      })();
+    </script>
+  </body>
+</html>

--- a/src/Monzo.lua
+++ b/src/Monzo.lua
@@ -25,7 +25,7 @@
 -- SOFTWARE.
 
 local BANK_CODE = "Monzo"
-local REDIRECT_URI = "https://www.janmuennich.com/moneymoney-redirect/"
+local REDIRECT_URI = "https://diederich.github.io/moneymoney-monzo/oauth-redirect/"
 
 WebBanking {
   version = 1.00,


### PR DESCRIPTION
Add a static redirect page at docs/oauth-redirect/index.html that
forwards the Monzo OAuth callback to moneymoney-app://oauth. This
replaces the external dependency with a page hosted from
this repository via GitHub Pages.