### PR TITLE
Token refresh with confidential client

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Inofficial extension to fetch transactions from [Monzo](https://monzo.com) for [
   - Create a new OAuth client via https://developers.monzo.com/apps/new
   - Add `https://diederich.github.io/moneymoney-monzo/oauth-redirect/` in the _Redirect URLs_ field (see [OAuth Redirect](#oauth-redirect) below)
   - Add something to the other fields, e.g. `MyMoneyMoneyExtension` as Name
-  - Set _Confidentiality_ to _Not Confidential_
+  - Set _Confidentiality_ to _Confidential_ (see [Token Refresh](#token-refresh) below)
   - Tap _Submit_
 
 ### Add an account in MoneyMoney
@@ -64,6 +64,18 @@ exit;
 ```
 
 Make sure to register the matching redirect URL in your Monzo OAuth client at https://developers.monzo.com/.
+
+# Token Refresh
+
+Monzo access tokens expire after a few hours. To avoid having to manually re-authenticate every day, the extension uses OAuth refresh tokens to renew the access token automatically.
+
+Refresh tokens are only issued to **Confidential** OAuth clients. That's why the setup above sets _Confidentiality_ to _Confidential_. With this enabled:
+
+- The first time you connect, you'll go through the full OAuth flow (and approve in the Monzo app)
+- After that, the extension silently refreshes the access token whenever it expires
+- You only need to re-authenticate if you don't use the extension for a long time, or if Monzo invalidates the session
+
+Note: Monzo's definition of "Confidential" assumes the client secret is kept on a server, not on user devices. In this case the secret is stored in MoneyMoney's local database on your Mac. This is a pragmatic trade-off for a local desktop banking app — keep your Mac and MoneyMoney database secure.
 
 # Feedback
 

--- a/src/Monzo.lua
+++ b/src/Monzo.lua
@@ -66,6 +66,13 @@ function InitializeSession2(protocol, bankCode, step, credentials, interactive)
       authenticated = whoami and whoami["authenticated"]
     end
 
+    -- Try to refresh the access token using the refresh token (only available
+    -- for confidential OAuth clients).
+    if not authenticated and LocalStorage.refreshToken then
+      print("Refreshing access token.")
+      authenticated = refreshAccessToken()
+    end
+
     -- Obtain OAuth 2.0 authorization code from web browser.
     if not authenticated then
       return {
@@ -94,6 +101,8 @@ function InitializeSession2(protocol, bankCode, step, credentials, interactive)
     -- Store access token and expiration date.
     LocalStorage.accessToken = json["access_token"]
     LocalStorage.expiresAt = os.time() + json["expires_in"]
+    -- Store refresh token if provided (only for confidential clients).
+    LocalStorage.refreshToken = json["refresh_token"]
 
     -- Token is in pre_verification state until approved in the Monzo app.
     return {
@@ -109,6 +118,35 @@ function InitializeSession2(protocol, bankCode, step, credentials, interactive)
       error("Login not approved. Please try again and approve in the Monzo app.")
     end
   end
+end
+
+-- Exchanges the stored refresh token for a new access token.
+-- Returns true on success, false otherwise.
+function refreshAccessToken()
+  local postContent = "grant_type=refresh_token" ..
+      "&client_id=" .. MM.urlencode(clientId) ..
+      "&client_secret=" .. MM.urlencode(clientSecret) ..
+      "&refresh_token=" .. MM.urlencode(LocalStorage.refreshToken)
+  local postContentType = "application/x-www-form-urlencoded"
+  local response = connection:request("POST", "https://api.monzo.com/oauth2/token", postContent, postContentType)
+  local json = JSON(response):dictionary()
+
+  if not json["access_token"] then
+    -- Refresh failed; clear stored tokens to force a full re-auth.
+    print("Refresh token rejected: " .. (json["error"] or "unknown error"))
+    LocalStorage.accessToken = nil
+    LocalStorage.refreshToken = nil
+    LocalStorage.expiresAt = nil
+    return false
+  end
+
+  LocalStorage.accessToken = json["access_token"]
+  LocalStorage.expiresAt = os.time() + json["expires_in"]
+  -- Refresh tokens rotate: store the new one.
+  if json["refresh_token"] then
+    LocalStorage.refreshToken = json["refresh_token"]
+  end
+  return true
 end
 
 function ListAccounts(knownAccounts)


### PR DESCRIPTION
The non-confidential OAuth client was getting a bit annoying with having to re-login every other day. So I changed the setup to a confidential client with automatic token refresh. It works great so far.

@diederich Do you have any concerns since you initially created the extension with a non-confidential client?